### PR TITLE
Fix on research finished crashes when some entities are open

### DIFF
--- a/scripts/blueprint-requests.lua
+++ b/scripts/blueprint-requests.lua
@@ -16,8 +16,8 @@ function lrm.blueprint_requests.get_inventory_entity(player, ent_text, action_tx
         end
     end
     
-    local logistic_point = entity and entity.get_logistic_point(defines.logistic_member_index.character_requester) or nil
-    local control_behavior = entity and entity.get_control_behavior() or nil
+    local logistic_point = entity and entity.get_logistic_point and entity.get_logistic_point(defines.logistic_member_index.character_requester) or nil
+    local control_behavior = entity and entity.get_control_behavior and entity.get_control_behavior() or nil
     
     if (
          ( ( not (logistic_point == nil) )


### PR DESCRIPTION
Fixes crashes when the UI for the Satellite Receiver, LTN Combinator, Crafting Combinator, or any other entities are open when the research finishes.

Check for if the method exists first before calling it.